### PR TITLE
Add institution_id and institution_name as optional fields on Payroll…

### DIFF
--- a/plaid/model/payroll_item.py
+++ b/plaid/model/payroll_item.py
@@ -84,6 +84,8 @@ class PayrollItem(ModelNormal):
             'payroll_income': ([PayrollIncomeObject],),  # noqa: E501
             'status': (PayrollItemStatus,),  # noqa: E501
             'updated_at': (datetime, none_type,),  # noqa: E501
+            'institution_id': (str, none_type),  # noqa: E501
+            'institution_name': (str, none_type),  # noqa: E501
         }
 
     @cached_property
@@ -97,6 +99,8 @@ class PayrollItem(ModelNormal):
         'payroll_income': 'payroll_income',  # noqa: E501
         'status': 'status',  # noqa: E501
         'updated_at': 'updated_at',  # noqa: E501
+        'institution_id': 'institution_id',  # noqa: E501
+        'institution_name': 'institution_name',  # noqa: E501
     }
 
     _composed_schemas = {}


### PR DESCRIPTION
Plaid's response to /credit/payroll_income/get
includes:
```
{
    "items": [
        {
            "accounts": [
                {
                    "account_id": "Dk7P7dPx1pToED7ZBnvRUMBKWkgr8KUE7mLRp",
                    "pay_frequency": "SEMI_MONTHLY",
                    "rate_of_pay": {
                        "pay_amount": 100000,
                        "pay_rate": "ANNUAL"
                    }
                }
            ],
            "institution_id": "",
            "institution_name": "",
            "item_id": "Dk7P7dPx1pToED7ZBnvRUMnwa3gLwBUvnMpkm",
            
```

Their OpenAPI spec does not include the institution_id and institution_name fields. This causes the plaid-python library to throw an exception: 

```
File /code/.local/lib/python3.10/site-packages/plaid/model_utils.py, line 114, in set_attribute
    raise ApiAttributeError(
plaid.exceptions.ApiAttributeError: PayrollItem has no attribute 'institution_id' at ['received_data']['items'][0]['institution_id']
```

Latest OpenAPI spec is available here: https://raw.githubusercontent.com/plaid/plaid-openapi/master/2020-09-14.yml

Grepping for PayrollItem shows:
```
    PayrollItem:
      title: PayrollItem
      type: object
      description: An object containing information about the payroll item.
      properties:
        item_id:
          $ref: '#/components/schemas/ItemId'
        accounts:
          type: array
          items:
            $ref: '#/components/schemas/PayrollIncomeAccountData'
        payroll_income:
          type: array
          items:
            $ref: '#/components/schemas/PayrollIncomeObject'
        status:
          $ref: '#/components/schemas/PayrollItemStatus'
        updated_at:
          type: string
          format: date-time
          description: Timestamp in [ISO 8601](https://wikipedia.org/wiki/ISO_8601) format (YYYY-MM-DDTHH:mm:ssZ) indicating the last time that the Item was updated.
          nullable: true
      required:
      - item_id
      - payroll_income
      - status
      - accounts
      - updated_at
      ```